### PR TITLE
fix: settings for young persons

### DIFF
--- a/bavaria/data/mid/data.py
+++ b/bavaria/data/mid/data.py
@@ -17,9 +17,6 @@ def execute(context):
         { "zone": "munich", "target": 0.57 },
         #{ "zone": "mrs", "target": 0.62 },
         { "zone": "external", "target": 0.82 }, # Bavaria value
-
-        # age limit
-        #{"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     data["bicycle_availability_constraints"] = [
@@ -80,9 +77,6 @@ def execute(context):
         { "zone": "umland", "age": (50, 64), "target": 0.20 },
         { "zone": "umland", "age": (65, 74), "target": 0.11 },
         { "zone": "umland", "age": (75, np.inf), "target": 0.11 },
-
-        # age limit
-        #{"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     return data

--- a/bavaria/data/mid/data.py
+++ b/bavaria/data/mid/data.py
@@ -17,6 +17,9 @@ def execute(context):
         { "zone": "munich", "target": 0.57 },
         #{ "zone": "mrs", "target": 0.62 },
         { "zone": "external", "target": 0.82 }, # Bavaria value
+
+        # age limit
+        {"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     data["bicycle_availability_constraints"] = [
@@ -77,6 +80,9 @@ def execute(context):
         { "zone": "umland", "age": (50, 64), "target": 0.20 },
         { "zone": "umland", "age": (65, 74), "target": 0.11 },
         { "zone": "umland", "age": (75, np.inf), "target": 0.11 },
+
+        # age limit
+        {"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     return data

--- a/bavaria/data/mid/data.py
+++ b/bavaria/data/mid/data.py
@@ -19,7 +19,7 @@ def execute(context):
         { "zone": "external", "target": 0.82 }, # Bavaria value
 
         # age limit
-        {"age": (-np.inf, 5), "target": 0.0 },
+        #{"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     data["bicycle_availability_constraints"] = [
@@ -82,7 +82,7 @@ def execute(context):
         { "zone": "umland", "age": (75, np.inf), "target": 0.11 },
 
         # age limit
-        {"age": (-np.inf, 5), "target": 0.0 },
+        #{"age": (-np.inf, 5), "target": 0.0 },
     ]
 
     return data

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -9,7 +9,7 @@ with inhabitants from Gemeinde level using Iterative Proportional Fitting
 
 def configure(context):
     context.stage("bavaria.ipf.prepare")
-    context.config("bavaria.minimum_age.employment", 0)
+    context.config("bavaria.minimum_age.employment", 16)
  
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -14,11 +14,6 @@ def configure(context):
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")
 
-    #print(df_population[df_population["age_class"] == 18]["weight"].sum())
-    #print(df_employment[df_employment["age_class"] == 20]["weight"].sum())
-    print(df_licenses_country[df_licenses_country["age_class"] == 21]["weight"].sum())
-    exit()
-
     # Construct a combined age class
     population_age_classes = np.sort(df_population["age_class"].unique())
     population_age_upper = list(population_age_classes[1:]) + [9999]
@@ -64,7 +59,7 @@ def execute(context):
     # Provide a prior based on the size of the age classes
     combined_age_classes_sizes = {
         lower: upper - lower for
-        lower, upper in { combined_age_classes[:-1], combined_age_classes[1:] }
+        lower, upper in zip(combined_age_classes[:-1], combined_age_classes[1:])
     }
     combined_age_classes_sizes[combined_age_classes[-1]] = 1.0
     df_model["weight"] *= df_model["combined_age_class"].apply(lambda c: combined_age_classes_sizes[c])

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -9,7 +9,7 @@ with inhabitants from Gemeinde level using Iterative Proportional Fitting
 
 def configure(context):
     context.stage("bavaria.ipf.prepare")
-    context.config("bavaria.minimum_employment_age", 0)
+    context.config("bavaria.minimum_age.employment", 0)
  
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")
@@ -21,7 +21,7 @@ def execute(context):
     employment_age_classes = np.sort(df_employment["age_class"].unique())
     employment_age_upper = list(employment_age_classes[1:]) + [9999]
 
-    minimum_employment_age = context.config("bavaria.minimum_employment_age")
+    minimum_employment_age = context.config("bavaria.minimum_age.employment")
 
     license_age_classes = np.sort(df_licenses_country["age_class"].unique())
     license_age_upper = list(license_age_classes[1:]) + [9999]

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -9,7 +9,7 @@ with inhabitants from Gemeinde level using Iterative Proportional Fitting
 
 def configure(context):
     context.stage("bavaria.ipf.prepare")
-    context.config("bavaria.minimum_employment_age", 16)
+    context.config("bavaria.minimum_employment_age", 0)
  
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -9,6 +9,7 @@ with inhabitants from Gemeinde level using Iterative Proportional Fitting
 
 def configure(context):
     context.stage("bavaria.ipf.prepare")
+    context.config("bavaria.minimum_employment_age", 16)
  
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")
@@ -20,13 +21,16 @@ def execute(context):
     employment_age_classes = np.sort(df_employment["age_class"].unique())
     employment_age_upper = list(employment_age_classes[1:]) + [9999]
 
+    minimum_employment_age = context.config("bavaria.minimum_employment_age")
+
     license_age_classes = np.sort(df_licenses_country["age_class"].unique())
     license_age_upper = list(license_age_classes[1:]) + [9999]
     
     combined_age_classes = np.array(np.sort(list(
         set(population_age_classes) | 
         set(employment_age_classes) |
-        set(license_age_classes))))
+        set(license_age_classes) | 
+        set([minimum_employment_age]))))
     
     population_age_mapping = {}
     employment_age_mapping = {}
@@ -97,6 +101,12 @@ def execute(context):
     
         target_weight = df_employment.loc[f_reference, "weight"].sum()
         targets.append(target_weight)
+
+    # Minimum employment age
+    f_model = df_model["combined_age_class"] < minimum_employment_age
+    f_model &= df_model["employed"]
+    selectors.append(f_model)
+    targets.append(0.0)
 
     # License country constraints
     combinations = list(itertools.product(unique_sexes, license_age_classes))

--- a/bavaria/ipf/model.py
+++ b/bavaria/ipf/model.py
@@ -14,6 +14,11 @@ def configure(context):
 def execute(context):
     df_population, df_employment, df_licenses_country, df_licenses_kreis = context.stage("bavaria.ipf.prepare")
 
+    #print(df_population[df_population["age_class"] == 18]["weight"].sum())
+    #print(df_employment[df_employment["age_class"] == 20]["weight"].sum())
+    print(df_licenses_country[df_licenses_country["age_class"] == 21]["weight"].sum())
+    exit()
+
     # Construct a combined age class
     population_age_classes = np.sort(df_population["age_class"].unique())
     population_age_upper = list(population_age_classes[1:]) + [9999]
@@ -55,6 +60,14 @@ def execute(context):
 
     df_model = pd.DataFrame(index = index).reset_index()
     df_model["weight"] = 1.0
+
+    # Provide a prior based on the size of the age classes
+    combined_age_classes_sizes = {
+        lower: upper - lower for
+        lower, upper in { combined_age_classes[:-1], combined_age_classes[1:] }
+    }
+    combined_age_classes_sizes[combined_age_classes[-1]] = 1.0
+    df_model["weight"] *= df_model["combined_age_class"].apply(lambda c: combined_age_classes_sizes[c])
 
     # Attach departement indices
     df_spatial = df_population[["commune_index", "departement_index"]].drop_duplicates()

--- a/bavaria/synthesis/population/enriched.py
+++ b/bavaria/synthesis/population/enriched.py
@@ -13,6 +13,10 @@ def configure(context):
     context.stage("bavaria.data.mid.zones")
     context.config("random_seed")
 
+    context.config("bavaria.minimum_age.car_availability", 0)
+    context.config("bavaria.minimum_age.bicycle_availability", 0)
+    context.config("bavaria.minimum_age.pt_subscription", 0)
+
 """
 This stage overrides car availability, bike availability and transit subscription based on MiD data
 """
@@ -49,6 +53,11 @@ def execute(context):
     df_persons["car_availability"] = 1.0
     constraints = mid["car_availability_constraints"]
 
+    constraints.append({ 
+        "age": (-np.inf, context.config("bavaria.minimum_age.car_availability") - 1), 
+        "target": 0.0 
+    })
+
     filters = []
     targets = []
 
@@ -82,6 +91,11 @@ def execute(context):
     # BIKE AVAILABILITY
     df_persons["bicycle_availability"] = 1.0
     constraints = mid["bicycle_availability_constraints"]
+
+    constraints.append({ 
+        "age": (-np.inf, context.config("bavaria.minimum_age.bicycle_availability") - 1), 
+        "target": 0.0 
+    })
 
     filters = []
     targets = []
@@ -118,6 +132,11 @@ def execute(context):
     # PT SUBSCRIPTION
     df_persons["has_pt_subscription"] = 1.0
     constraints = mid["pt_subscription_constraints"]
+
+    constraints.append({ 
+        "age": (-np.inf, context.config("bavaria.minimum_age.pt_subscription") - 1), 
+        "target": 0.0 
+    })
 
     filters = []
     targets = []

--- a/bavaria/synthesis/population/enriched.py
+++ b/bavaria/synthesis/population/enriched.py
@@ -13,9 +13,9 @@ def configure(context):
     context.stage("bavaria.data.mid.zones")
     context.config("random_seed")
 
-    context.config("bavaria.minimum_age.car_availability", 0)
-    context.config("bavaria.minimum_age.bicycle_availability", 0)
-    context.config("bavaria.minimum_age.pt_subscription", 0)
+    context.config("bavaria.minimum_age.car_availability", 5)
+    context.config("bavaria.minimum_age.bicycle_availability", 5)
+    context.config("bavaria.minimum_age.pt_subscription", 5)
 
 """
 This stage overrides car availability, bike availability and transit subscription based on MiD data

--- a/bavaria/synthesis/population/enriched.py
+++ b/bavaria/synthesis/population/enriched.py
@@ -13,9 +13,9 @@ def configure(context):
     context.stage("bavaria.data.mid.zones")
     context.config("random_seed")
 
-    context.config("bavaria.minimum_age.car_availability", 5)
-    context.config("bavaria.minimum_age.bicycle_availability", 5)
-    context.config("bavaria.minimum_age.pt_subscription", 5)
+    context.config("bavaria.minimum_age.car_availability", 0)
+    context.config("bavaria.minimum_age.bicycle_availability", 0)
+    context.config("bavaria.minimum_age.pt_subscription", 0)
 
 """
 This stage overrides car availability, bike availability and transit subscription based on MiD data

--- a/bavaria/synthesis/population/enriched.py
+++ b/bavaria/synthesis/population/enriched.py
@@ -53,7 +53,17 @@ def execute(context):
     targets = []
 
     for constraint in constraints:
-        f = df_persons["inside_{}".format(constraint["zone"])]
+        f = np.ones((len(df_persons),), dtype = bool)
+
+        if "zone" in constraint:
+            f &= df_persons["inside_{}".format(constraint["zone"])]
+        
+        if "sex" in constraint:
+            f &= df_persons["sex"] == constraint["sex"]
+
+        if "age" in constraint:
+            f &= df_persons["age"].between(*constraint["age"])
+
         targets.append(constraint["target"] * np.count_nonzero(f))
         filters.append(f)
 


### PR DESCRIPTION
- All persons <16 have `employed` = `false` now
- Configurable minimum age for car and bike availability (default 0)
- Configurable minimum age for public transport subscription (default 0)